### PR TITLE
Detect if running inside container

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -10,3 +10,4 @@ aspell: aspell
 aspell_en: aspell-en
 cron: cron
 sudo: sudo
+iptraf_ng: iptraf-ng

--- a/local.yml
+++ b/local.yml
@@ -16,6 +16,7 @@
     - "{{ bind_utils }}"
     - "{{ aspell }}"
     - "{{ aspell_en }}"
+    - "{{ iptraf_ng }}"
 
   roles:
   - tmux

--- a/roles/bash/templates/prompt.bash.j2
+++ b/roles/bash/templates/prompt.bash.j2
@@ -19,7 +19,15 @@ function __prompt_command()
  
 
     #PS1
-    PS1+="${RCol}${Gre}\u${RCol}@${BBlu}\h ${Pur}\w"
+    PS1+="${RCol}${Gre}\u${RCol}@${BBlu}\h"
+
+    local IS_CONTAINER=$(cat /proc/self/cgroup | grep -c docker)
+    if [ "$IS_CONTAINER" != "0" ]; then
+       PS1+="${BBlu}[C]${RCol}"
+    fi
+
+    #Path
+    PS1+=" ${Pur}\w"
 
     local GIT_BRANCH=$(git branch 2>/dev/null | grep "^*" | colrm 1 2)
     if [ "$GIT_BRANCH" != "" ]; then


### PR DESCRIPTION
* If the bash is inside a container it appends a `[C]` to the prompt.
  Probably this should be improved to detect different virtualization if possible.
* Install iptraf-ng.